### PR TITLE
Make pip installable

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include README.md
+include LICENSE
+include *.py
+recursive-include beampy *
+recursive-include examples *
+recursive-include tests *

--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,6 @@ setup(
         "beautifulsoup4",
         "pillow",
         "six",
+        "lxml",
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="beampy",
+    version="0.0.0",
+    long_description=__doc__,
+    packages=find_packages(),
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=[
+        "beautifulsoup4",
+        "pillow",
+        "six",
+    ]
+)


### PR DESCRIPTION
This is a minimal set of files to make things pip installable with the following command:

    pip install -e git+https://github.com/hchauvet/beampy.git#egg=beampy