### PR TITLE
Extra LaTeX packages in text

### DIFF
--- a/beampy/modules/text.py
+++ b/beampy/modules/text.py
@@ -178,7 +178,9 @@ class text(beampy_module):
             \usepackage{amssymb}
             """
 
-            pretex += '\n'.join(self.extra_packages + document._latex_packages)
+            for extra_package in self.extra_packages + document._latex_packages :
+                pretex += r'\usepackage{' + extra_package + '}\n'
+
             pretex += r'\begin{document}'
             pretex += self.latex_text
             pretex += r'\end{document}'


### PR DESCRIPTION
Hi Hugo,

The extra_packages argument in text was not working. This is an easy fix.

Thanks,
Olivier.