### PR TITLE
Add tail to temporary svg file

### DIFF
--- a/beampy/functions.py
+++ b/beampy/functions.py
@@ -525,6 +525,8 @@ def convert_pdf_to_svg(pdf_input_file, temp_directory='local'):
     local_directory, filename_pdf = os.path.split(pdf_input_file)
     filename = os.path.splitext(filename_pdf)[0]
 
+    filename += hashlib.md5( filename.encode('utf8') ).hexdigest()
+
     if temp_directory == 'local':
         temp_directory = local_directory
     if len(temp_directory) > 0:

--- a/beampy/functions.py
+++ b/beampy/functions.py
@@ -525,7 +525,7 @@ def convert_pdf_to_svg(pdf_input_file, temp_directory='local'):
     local_directory, filename_pdf = os.path.split(pdf_input_file)
     filename = os.path.splitext(filename_pdf)[0]
 
-    filename += hashlib.md5( filename.encode('utf8') ).hexdigest()
+    filename += hashlib.md5( filename.encode('utf8') ).hexdigest()[:10]
 
     if temp_directory == 'local':
         temp_directory = local_directory


### PR DESCRIPTION
Hi Hugo,

If there are two files in the current directory, `toto.svg` and `toto.pdf`, then including the latter in the slideshow erases the first one from the directory.

One way to solve the issue is to make this situation unlikely by adding a complicated tail to the temporary file's name.

Best,
Olivier.


