### PR TITLE
pdfjoin to pdfjam

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Beampy [![Build Status](https://travis-ci.com/hchauvet/beampy.svg)](https://travis-ci.com/hchauvet/beampy) [![codecov](https://codecov.io/gh/hchauvet/beampy/graph/badge.svg)](https://codecov.io/gh/hchauvet/beampy) ![pypi python version](https://img.shields.io/pypi/pyversions/beampy-slideshow.svg) ![pypi licence](https://img.shields.io/pypi/l/beampy-slideshow.svg) ![pypi download](https://img.shields.io/pypi/dm/beampy-slideshow.svg) ![pypi beampy version](https://img.shields.io/pypi/v/beampy-slideshow.svg)
 
+**The development of the master branch is currently frozen, (only urgent bug fix will be pushed), the new version of beampy is currently developped in the dev branch which is still not enouth stable to use...**
+
 Beampy is a python tool to create slide-show in svg that can be displayed with HTML5
 (tested on Firefox and Chromium)
 The size of slides is fixed, like in a Latex Beamer document.

--- a/beampy/document.py
+++ b/beampy/document.py
@@ -356,6 +356,15 @@ class document():
                         document._external_cmd[progname] = find_avconv
                     else:
                         missing = True
+
+                # pdfjoin has disappeared from texlive-extra-utils (debian) (https://askubuntu.com/questions/1244384/where-is-pdfjoin-ubuntu-18-04-and-later)
+                elif progname == 'pdfjoin' : 
+                    find_pdfjoin = find_executable('pdfjam')
+                    if find_pdfjoin is not None:
+                        document._external_cmd[progname] = find_pdfjoin + " --fitpaper true --rotateoversize true --suffix joined"
+                    else:
+                        missing = True                   
+
                 else:
                     find_app = find_executable(progname)
                     if find_app is not None:

--- a/beampy/modules/text.py
+++ b/beampy/modules/text.py
@@ -178,7 +178,10 @@ class text(beampy_module):
             \usepackage{amssymb}
             """
 
-            pretex += '\n'.join(self.extra_packages + document._latex_packages)
+            for extra_package in self.extra_packages + document._latex_packages :
+                pretex += r'\usepackage{' + extra_package + '}\n'
+
+            #pretex += '\n'.join(self.extra_packages + document._latex_packages)
             pretex += r'\begin{document}'
             pretex += self.latex_text
             pretex += r'\end{document}'

--- a/doc-src/install.rst
+++ b/doc-src/install.rst
@@ -30,6 +30,7 @@ Python libraries
 * **Python Image Library (PIL)**: to minipulate images.
 * **pygments**: [Optional] allows to add code syntax coloration to display code in your presentation.
 * **bokeh**: [Optional] Include `bokeh <https://bokeh.pydata.org/en/latest/>`_ interactive plots in your presentation. **Need bokeh version >= 0.12.6**
+* **bibtexparser**: [Optional] LaTeX bibliography.
 
 Beampy also includes a version of `scour <https://github.com/codedread/scour>`_, an svg optimiser.
 
@@ -43,7 +44,7 @@ Install dependencies using apt-get
 
 .. code-block:: bash
 
-   sudo apt-get install ffmpeg inkscape texlive-extra-utils texlive-latex-extra pdf2svg python-pil python-beautifulsoup
+   sudo install ffmpeg inkscape texlive-extra-utils texlive-latex-extra pdf2svg python3-pil python3-bs4 python3-bibtexparser
 
 From Python pip
 ***************


### PR DESCRIPTION
Hi Hugo,

Pdfjoin disappeared from the Debian package texlive-extra-utils. Beampy can use the mother program pdfjam instead.

Thanks,
Olivier.